### PR TITLE
Workaround for PropertyInfo.GetValue il2cpp issue

### DIFF
--- a/src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
+++ b/src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
@@ -517,7 +517,7 @@ namespace Newtonsoft.Json.Utilities
                 case MemberTypes.Property:
                     try
                     {
-                        return ((PropertyInfo)member).GetValue(target, null);
+                        return ((PropertyInfo)member).GetValue(target, BindingFlags.Default, null, null, null);
                     }
                     catch (TargetParameterCountException e)
                     {


### PR DESCRIPTION
[Details](https://forum.unity3d.com/threads/unity-5-0-3f2-il2cpp-problem-attempting-to-call-method-system-reflection-monoproperty-getteradapt.332335/#post-3153825)